### PR TITLE
Improve UIColor extension

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Extensions/UIColor.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Extensions/UIColor.swift
@@ -6,31 +6,23 @@
 //  Copyright © 2018 Amahi. All rights reserved.
 //
 
-import Foundation
+import UIKit.UIColor
 
 extension UIColor {
     
     class var softYellow: UIColor {
-        get {
-            return UIColor(red:0.81, green:0.85, blue:0.26, alpha:0.7)
-        }
+        return UIColor(red: 0.81, green: 0.85, blue: 0.26, alpha: 0.7)
     }
     
     class var remoteIndicatorBrown: UIColor {
-        get {
-            return UIColor(red:152/255, green:38/255, blue:73/255, alpha:1)
-        }
+        return UIColor(red: 152 / 255.0, green: 38 / 255.0, blue: 73 / 255.0, alpha: 1)
     }
     
     class var localIndicatorBlack: UIColor {
-        get {
-            return UIColor(red:28/255, green:28/255, blue:31/255, alpha:1)
-        }
+        return UIColor(red: 28 / 255.0, green: 28 / 255.0, blue: 31 / 255.0, alpha: 1)
     }
     
     class var brokenIndicatorRed : UIColor {
-        get {
-            return UIColor(red:211/255, green:33/255, blue:45/255, alpha:1)
-        }
+        return UIColor(red: 211 / 255.0, green: 33 / 255.0, blue: 45 / 255.0, alpha: 1)
     }
 }


### PR DESCRIPTION
- Simplify the declaration of a read-only computed property by removing get keyword
- Fix incorrect import (Foundation is not enough to work with UIColor)
- Fix an incorrect data type of the parameters (the previous implementation will not work correctly if UIColor's initializer with Int type parameters appears)
- Correct the indents between operands