### PR TITLE
* fix: Issues with audio player choking on flac files. fixes #172

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Data/Local/LocalStorage.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Data/Local/LocalStorage.swift
@@ -56,7 +56,7 @@ final class LocalStorage: NSObject {
         set {
             LocalStorage.shared.persistString(string: newValue.rawValue,
                                               key: PersistenceIdentifiers.prefConnection)
-            ServerApi.shared!.configureConnection()
+            ServerApi.shared?.configureConnection()
         }
         get {
             if let connection = LocalStorage.shared.getString(key: PersistenceIdentifiers.prefConnection) {

--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesPresenter.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesPresenter.swift
@@ -111,7 +111,7 @@ internal class FilesPresenter: BasePresenter {
             self.view?.present(controller)
             break
             
-        case MimeType.video, MimeType.compressedMedia:
+        case MimeType.video, MimeType.flacMedia:
             // TODO: open VideoPlayer and play the file
             guard let url = ServerApi.shared!.getFileUri(file) else {
                 AmahiLogger.log("Invalid file URL, file cannot be opened")

--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesPresenter.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesPresenter.swift
@@ -27,7 +27,7 @@ internal protocol FilesView : BaseView {
     func webViewOpenContent(at url: URL, mimeType: MimeType)
     
     func shareFile(at url: URL, from sender : UIView?)
-
+    
     func updateDownloadProgress(for row: Int, downloadJustStarted: Bool, progress: Float)
     
     func dismissProgressIndicator(at url: URL, completion: @escaping () -> Void)
@@ -100,6 +100,8 @@ internal class FilesPresenter: BasePresenter {
         
         let type = Mimes.shared.match(file.mime_type!)
         
+        AmahiLogger.log(": Matched type is \(type) , File MIMETYPE \(file.mime_type)")
+        
         switch type {
             
         case MimeType.image:
@@ -109,7 +111,7 @@ internal class FilesPresenter: BasePresenter {
             self.view?.present(controller)
             break
             
-        case MimeType.video:
+        case MimeType.video, MimeType.compressedMedia:
             // TODO: open VideoPlayer and play the file
             guard let url = ServerApi.shared!.getFileUri(file) else {
                 AmahiLogger.log("Invalid file URL, file cannot be opened")
@@ -122,7 +124,7 @@ internal class FilesPresenter: BasePresenter {
         case MimeType.audio:
             let audioURLs = prepareAudioItems(files)
             var arrangedURLs = [URL]()
-                
+            
             for (index, url) in audioURLs.enumerated() {
                 if (index < fileIndex) {
                     arrangedURLs.insert(url, at: arrangedURLs.endIndex)
@@ -167,7 +169,7 @@ internal class FilesPresenter: BasePresenter {
     
     public func shareFile(_ file: ServerFile, fileIndex: Int,from sender : UIView?) {
         let type = Mimes.shared.match(file.mime_type!)
-
+        
         if FileManager.default.fileExistsInCache(file){
             let path = FileManager.default.localPathInCache(for: file)
             self.view?.shareFile(at: path, from: sender)
@@ -209,10 +211,10 @@ internal class FilesPresenter: BasePresenter {
     }
     
     private func downloadFile(at fileIndex: Int ,
-                      _ serverFile: ServerFile,
-                      mimeType: MimeType,
-                      from sender : UIView?,
-                      completion: @escaping (_ filePath: URL) -> Void) {
+                              _ serverFile: ServerFile,
+                              mimeType: MimeType,
+                              from sender : UIView?,
+                              completion: @escaping (_ filePath: URL) -> Void) {
         
         self.view?.updateDownloadProgress(for: fileIndex, downloadJustStarted: true, progress: 0.0)
         
@@ -272,15 +274,15 @@ internal class FilesPresenter: BasePresenter {
         
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "OfflineFile")
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "downloadDate", ascending: false)]
-
+        
         let delegate = UIApplication.shared.delegate as! AppDelegate
         let stack = delegate.stack
-                
+        
         fetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest,
                                                               managedObjectContext: stack.context,
                                                               sectionNameKeyPath: nil, cacheName: nil)
         if let files = fetchedResultsController?.fetchedObjects as! [OfflineFile]? {
-     
+            
             var dictionary = [String : OfflineFile]()
             
             for file in files {

--- a/AmahiAnywhere/AmahiAnywhere/Utils/Mimes.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Utils/Mimes.swift
@@ -27,6 +27,7 @@ public class Mimes {
         types.updateValue(MimeType.archive, forKey: "application/x-rar-compressed")
         
         types.updateValue(MimeType.audio, forKey: "application/ogg")
+        // breaking out flac on its own type because of https://github.com/amahi/ios/issues/172
         types.updateValue(MimeType.flacMedia, forKey: "application/x-flac")
         
         types.updateValue(MimeType.code, forKey: "text/css")

--- a/AmahiAnywhere/AmahiAnywhere/Utils/Mimes.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Utils/Mimes.swift
@@ -27,7 +27,7 @@ public class Mimes {
         types.updateValue(MimeType.archive, forKey: "application/x-rar-compressed")
         
         types.updateValue(MimeType.audio, forKey: "application/ogg")
-        types.updateValue(MimeType.audio, forKey: "application/x-flac")
+        types.updateValue(MimeType.compressedMedia, forKey: "application/x-flac")
         
         types.updateValue(MimeType.code, forKey: "text/css")
         types.updateValue(MimeType.code, forKey: "text/html")
@@ -44,10 +44,10 @@ public class Mimes {
         types.updateValue(MimeType.document, forKey: "application/x-abiword")
         types.updateValue(MimeType.document, forKey: "application/x-kword")
         types.updateValue(MimeType.document, forKey: "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
-
+        
         types.updateValue(MimeType.sharedFile, forKey: "application/epub+zip")
         types.updateValue(MimeType.sharedFile, forKey: "application/x-mobipocket")
-
+        
         types.updateValue(MimeType.directory, forKey: "text/directory")
         
         types.updateValue(MimeType.image, forKey: "application/vnd.oasis.opendocument.graphics")
@@ -69,14 +69,24 @@ public class Mimes {
     }
     
     public func match(_ mime: String) -> MimeType {
-    
+        
         let type = matchKnown(mime);
-    
+        
         if type != MimeType.undefined {
             return type;
         } else {
+            if isCompressedMedia(mime) {
+                return .compressedMedia
+            }
             return matchCategory(mime)
         }
+    }
+    
+    private func isCompressedMedia(_ mime: String) -> Bool {
+        let fileExtensionType = mime.split(separator: "/")[1]
+        
+        AmahiLogger.log("\(fileExtensionType)")
+        return fileExtensionType == "flac"
     }
     
     private func matchKnown(_ mime: String) -> MimeType {
@@ -88,22 +98,22 @@ public class Mimes {
     
     private func matchCategory(_ mime: String) -> MimeType {
         let type = mime.split(separator: "/")[0]
-    
+        
         switch type {
-            case "audio":
-                return MimeType.audio
-            case "image":
-                return MimeType.image
-            case "text":
-                return MimeType.document
-            case "video":
-                return MimeType.video
-            default:
-                return MimeType.undefined
+        case "audio":
+            return MimeType.audio
+        case "image":
+            return MimeType.image
+        case "text":
+            return MimeType.document
+        case "video":
+            return MimeType.video
+        default:
+            return MimeType.undefined
         }
     }
 }
 
 public enum MimeType: Int {
-    case undefined = 1, archive, audio, code, sharedFile, document, directory, image, presentation, spreadsheet, video, subtitle
+    case undefined = 1, archive, audio, code, sharedFile, document, directory, image, presentation, spreadsheet, video, subtitle , compressedMedia
 }

--- a/AmahiAnywhere/AmahiAnywhere/Utils/Mimes.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Utils/Mimes.swift
@@ -27,7 +27,7 @@ public class Mimes {
         types.updateValue(MimeType.archive, forKey: "application/x-rar-compressed")
         
         types.updateValue(MimeType.audio, forKey: "application/ogg")
-        types.updateValue(MimeType.compressedMedia, forKey: "application/x-flac")
+        types.updateValue(MimeType.flacMedia, forKey: "application/x-flac")
         
         types.updateValue(MimeType.code, forKey: "text/css")
         types.updateValue(MimeType.code, forKey: "text/html")
@@ -75,17 +75,14 @@ public class Mimes {
         if type != MimeType.undefined {
             return type;
         } else {
-            if isCompressedMedia(mime) {
-                return .compressedMedia
-            }
+            
             return matchCategory(mime)
         }
     }
     
-    private func isCompressedMedia(_ mime: String) -> Bool {
+    private func isFlacMedia(_ mime: String) -> Bool {
         let fileExtensionType = mime.split(separator: "/")[1]
         
-        AmahiLogger.log("\(fileExtensionType)")
         return fileExtensionType == "flac"
     }
     
@@ -98,6 +95,10 @@ public class Mimes {
     
     private func matchCategory(_ mime: String) -> MimeType {
         let type = mime.split(separator: "/")[0]
+        
+        if isFlacMedia(mime) {
+            return .flacMedia
+        }
         
         switch type {
         case "audio":
@@ -115,5 +116,5 @@ public class Mimes {
 }
 
 public enum MimeType: Int {
-    case undefined = 1, archive, audio, code, sharedFile, document, directory, image, presentation, spreadsheet, video, subtitle , compressedMedia
+    case undefined = 1, archive, audio, code, sharedFile, document, directory, image, presentation, spreadsheet, video, subtitle , flacMedia
 }


### PR DESCRIPTION
What I did,

Added a new mimetype `compressedMedia` for a flac file. For now all .flac files are played with VLC kit via the VideoPlayer. We can support more compressed media by matching their mime type to the compressedMedia type