### PR TITLE
thumbnail regeneration resolved

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Cells/FilesBaseCollectionViewCell.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Cells/FilesBaseCollectionViewCell.swift
@@ -31,9 +31,9 @@ class FilesBaseCollectionCell: SwipeCollectionViewCell{
             break
             
         case .video:
-            
-            if let image = VideoThumbnailGenerator.imageFromMemory(for: url) {
-                iconImageView.image = image
+            iconImageView.sd_setImage(with: url, placeholderImage: UIImage(named: "video"), options: .refreshCached)
+            if iconImageView.image != nil {
+                AmahiLogger.log("Video Thumbnail for \(url) obtained from cache")
             } else {
                 iconImageView.image = UIImage(named: "video")
                 DispatchQueue.global(qos: .background).async {
@@ -47,9 +47,9 @@ class FilesBaseCollectionCell: SwipeCollectionViewCell{
             break
             
         case .audio:
-            
-            if let image = AudioThumbnailGenerator.imageFromMemory(for: url) {
-                iconImageView.image = image
+            iconImageView.sd_setImage(with: url, placeholderImage: UIImage(named: "audio"), options: .refreshCached)
+            if iconImageView.image != nil {
+                AmahiLogger.log("Audio Thumbnail for \(url) obtained from cache")
             } else {
                 iconImageView.image = UIImage(named: "audio")
                 DispatchQueue.global(qos: .background).async {
@@ -64,8 +64,9 @@ class FilesBaseCollectionCell: SwipeCollectionViewCell{
             
         case .presentation, .document, .spreadsheet:
             
-            if let image = PDFThumbnailGenerator.imageFromMemory(for: url) {
-                iconImageView.image = image
+            iconImageView.sd_setImage(with: url, placeholderImage: UIImage(named: "file"), options: .refreshCached)
+            if iconImageView.image != nil {
+                AmahiLogger.log("Document Thumbnail for \(url) obtained from cache")
             } else {
                 iconImageView.image = UIImage(named: "file")
                 


### PR DESCRIPTION
Previously, new thumbnails for files were being generated every time we opened a folder and thus it would take time for thumbnails (audio, video, documents) to load. 

Now, thumbnails are generated only once and then loaded from cache whenever called. It can be verified in the logs. 

