### PR TITLE
Added mini controller 

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere.xcodeproj/project.pbxproj
+++ b/AmahiAnywhere/AmahiAnywhere.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		8A0A88F8227CE39C00A1360C /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4612851D2051DB770061EC21 /* MimeType.swift */; };
 		8A67FC2B22666F81005A5038 /* OfflineFile+MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A67FC2A22666F81005A5038 /* OfflineFile+MimeType.swift */; };
 		9938343D22CBAAA2002A8213 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9938343C22CBAAA2002A8213 /* Toast.swift */; };
+		993EC87522E6959800AF5F1F /* RootContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993EC87422E6959800AF5F1F /* RootContainerViewController.swift */; };
 		99CF9D7F22E288BB0060C0E5 /* QueueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CF9D7E22E288BB0060C0E5 /* QueueViewController.swift */; };
 		AD8F2FDB226E9331009C8C4B /* CoreDataStack+DropDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8F2FD9226E9331009C8C4B /* CoreDataStack+DropDatabase.swift */; };
 		AD8F2FDC226E9331009C8C4B /* CoreDataStack+AutoSaving.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8F2FDA226E9331009C8C4B /* CoreDataStack+AutoSaving.swift */; };
@@ -166,6 +167,7 @@
 		8A67FC2A22666F81005A5038 /* OfflineFile+MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OfflineFile+MimeType.swift"; sourceTree = "<group>"; };
 		9913634D22D5D2F100B48586 /* AmahiAnywhere.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AmahiAnywhere.entitlements; sourceTree = "<group>"; };
 		9938343C22CBAAA2002A8213 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
+		993EC87422E6959800AF5F1F /* RootContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootContainerViewController.swift; sourceTree = "<group>"; };
 		99CF9D7E22E288BB0060C0E5 /* QueueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueViewController.swift; sourceTree = "<group>"; };
 		AD8F2FD9226E9331009C8C4B /* CoreDataStack+DropDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CoreDataStack+DropDatabase.swift"; sourceTree = "<group>"; };
 		AD8F2FDA226E9331009C8C4B /* CoreDataStack+AutoSaving.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CoreDataStack+AutoSaving.swift"; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 			isa = PBXGroup;
 			children = (
 				99CF9D7E22E288BB0060C0E5 /* QueueViewController.swift */,
+				993EC87422E6959800AF5F1F /* RootContainerViewController.swift */,
 			);
 			path = Cast;
 			sourceTree = "<group>";
@@ -780,6 +783,7 @@
 				C8DA5B2020D5E09000F5A527 /* FilesViewController+UISearchDelegate.swift in Sources */,
 				04BA8996211D56F400E7A868 /* AmahiLogger.swift in Sources */,
 				3BCAFBB122C6DC460044057E /* OfflineFilesViewController+FilesView.swift in Sources */,
+				993EC87522E6959800AF5F1F /* RootContainerViewController.swift in Sources */,
 				AD8F2FDB226E9331009C8C4B /* CoreDataStack+DropDatabase.swift in Sources */,
 				3BB315D422E1143600A0FDAD /* SharesCollectionViewCell.swift in Sources */,
 				3BF4592822CD702C00C020A4 /* GlobalLayoutView.swift in Sources */,

--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Cast/RootContainerViewController.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Cast/RootContainerViewController.swift
@@ -1,0 +1,98 @@
+//
+//  RootContainerViewController.swift
+//  AmahiAnywhere
+//
+//  Created by Abhishek Sansanwal on 23/07/19.
+//  Copyright © 2019 Amahi. All rights reserved.
+//
+
+import GoogleCast
+import UIKit
+
+let kCastControlBarsAnimationDuration: TimeInterval = 0.20
+
+@objc(RootContainerViewController)
+class RootContainerViewController: UIViewController, GCKUIMiniMediaControlsViewControllerDelegate {
+    @IBOutlet private var _miniMediaControlsContainerView: UIView!
+    @IBOutlet private var _miniMediaControlsHeightConstraint: NSLayoutConstraint!
+    private var miniMediaControlsViewController: GCKUIMiniMediaControlsViewController!
+    var miniMediaControlsViewEnabled = false {
+        didSet {
+            if isViewLoaded {
+                updateControlBarsVisibility()
+            }
+        }
+    }
+    
+    var overridenNavigationController: UINavigationController?
+    override var navigationController: UINavigationController? {
+        get {
+            return overridenNavigationController
+        }
+        set {
+            overridenNavigationController = newValue
+        }
+    }
+    
+    var miniMediaControlsItemEnabled = false
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let castContext = GCKCastContext.sharedInstance()
+        miniMediaControlsViewController = castContext.createMiniMediaControlsViewController()
+        miniMediaControlsViewController.delegate = self
+        updateControlBarsVisibility()
+        installViewController(miniMediaControlsViewController,
+                              inContainerView: _miniMediaControlsContainerView)
+        for _ in 1...20 {
+            print("HEEYA")
+        }
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+    
+    // MARK: - Internal methods
+    
+    func updateControlBarsVisibility() {
+        if miniMediaControlsViewEnabled, miniMediaControlsViewController.active {
+            _miniMediaControlsHeightConstraint.constant = miniMediaControlsViewController.minHeight
+            view.bringSubviewToFront(_miniMediaControlsContainerView)
+        } else {
+            _miniMediaControlsHeightConstraint.constant = 0
+        }
+        UIView.animate(withDuration: kCastControlBarsAnimationDuration, animations: { () -> Void in
+            self.view.layoutIfNeeded()
+        })
+        view.setNeedsLayout()
+    }
+    
+    func installViewController(_ viewController: UIViewController?, inContainerView containerView: UIView) {
+        if let viewController = viewController {
+            addChild(viewController)
+            viewController.view.frame = containerView.bounds
+            containerView.addSubview(viewController.view)
+            viewController.didMove(toParent: self)
+        }
+    }
+    
+    func uninstallViewController(_ viewController: UIViewController) {
+        viewController.willMove(toParent: nil)
+        viewController.view.removeFromSuperview()
+        viewController.removeFromParent()
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender _: Any?) {
+        if segue.identifier == "NavigationVCEmbedSegue" {
+            navigationController = (segue.destination as? UINavigationController)
+        }
+    }
+    
+    // MARK: - GCKUIMiniMediaControlsViewControllerDelegate
+    
+    func miniMediaControlsViewController(_: GCKUIMiniMediaControlsViewController,
+                                         shouldAppear _: Bool) {
+        updateControlBarsVisibility()
+    }
+}

--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Login/LoginViewController.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Login/LoginViewController.swift
@@ -111,7 +111,7 @@ class LoginViewController: BaseUIViewController {
 extension LoginViewController: LoginView {
     
     func showHome() {
-        let serverVc = self.instantiateViewController (withIdentifier: StoryBoardIdentifiers.tabBarController, from: StoryBoardIdentifiers.main)
+        let serverVc = self.instantiateViewController (withIdentifier: "RootVC", from: StoryBoardIdentifiers.main)
         self.present(serverVc, animated: true, completion: nil)
     }
     

--- a/AmahiAnywhere/AmahiAnywhere/StoryBoards/Base.lproj/Main.storyboard
+++ b/AmahiAnywhere/AmahiAnywhere/StoryBoards/Base.lproj/Main.storyboard
@@ -261,11 +261,11 @@
             <objects>
                 <viewController storyboardIdentifier="ServerViewController" id="Dbq-Bw-ca9" customClass="ServerViewController" customModule="AmahiAnywhere" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="LDY-OA-sHr">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="odh-ji-ZnE">
-                                <rect key="frame" x="20" y="484" width="335" height="50"/>
+                                <rect key="frame" x="20" y="464" width="335" height="50"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The selected HDA is currently not available" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="Nae-3S-Fzo">
                                         <rect key="frame" x="10" y="0.0" width="315" height="50"/>
@@ -295,7 +295,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" dataMode="prototypes" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VNe-vj-6KD">
-                                <rect key="frame" x="0.0" y="56" width="375" height="498"/>
+                                <rect key="frame" x="0.0" y="56" width="375" height="478"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="20" minimumInteritemSpacing="10" id="0ur-he-7fE">
                                     <size key="itemSize" width="138" height="144"/>
@@ -476,7 +476,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="SettingsViewController" automaticallyAdjustsScrollViewInsets="NO" id="teI-x8-nnt" customClass="SettingsViewController" customModule="AmahiAnywhere" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" indicatorStyle="black" bouncesZoom="NO" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="lKs-ES-BcF">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.12156862745098039" green="0.12941176470588234" blue="0.14117647058823529" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="separatorColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -577,7 +577,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="ConnectionViewController" automaticallyAdjustsScrollViewInsets="NO" id="Mr0-gg-hDA" customClass="ConnectionViewController" customModule="AmahiAnywhere" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="LUY-ls-ZtF">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.12156862745098039" green="0.12941176470588234" blue="0.14117647058823529" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1033,7 +1033,7 @@
             <objects>
                 <viewController id="oee-xO-Kjc" userLabel="Offline Files" customClass="OfflineFilesViewController" customModule="AmahiAnywhere" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="uSv-Qn-vLa" userLabel="Server Files">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aye-ox-RCD">
@@ -1053,7 +1053,7 @@
                                 </connections>
                             </button>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="xYS-us-p6h">
-                                <rect key="frame" x="0.0" y="134" width="375" height="533"/>
+                                <rect key="frame" x="0.0" y="134" width="375" height="513"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="aLY-VL-fkc">
                                     <size key="itemSize" width="50" height="50"/>
@@ -1426,6 +1426,52 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qgV-7i-smB" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="361" y="1081"/>
+        </scene>
+        <!--Root Container View Controller-->
+        <scene sceneID="MHp-Z1-nMQ">
+            <objects>
+                <viewController storyboardIdentifier="RootVC" id="Kwh-kw-xtv" customClass="RootContainerViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="bpm-42-M2C"/>
+                        <viewControllerLayoutGuide type="bottom" id="7lo-ZG-yem"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="i3P-mu-uGU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Jg-9l-J7K">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <connections>
+                                    <segue destination="ght-RR-FaW" kind="embed" identifier="NavigationVCEmbedSegue" id="uUJ-Qn-wEL"/>
+                                </connections>
+                            </containerView>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="foD-v2-PKP">
+                                <rect key="frame" x="0.0" y="578" width="375" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="NUJ-lX-JXR"/>
+                                </constraints>
+                            </containerView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.1623205543" green="0.17308300730000001" blue="0.18661126489999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="foD-v2-PKP" firstAttribute="width" secondItem="i3P-mu-uGU" secondAttribute="width" id="5bq-FZ-S2P"/>
+                            <constraint firstItem="foD-v2-PKP" firstAttribute="bottom" secondItem="7lo-ZG-yem" secondAttribute="top" constant="-49" id="Thn-Fy-9Lr"/>
+                            <constraint firstItem="7lo-ZG-yem" firstAttribute="top" secondItem="8Jg-9l-J7K" secondAttribute="bottom" id="Vi1-YN-saR"/>
+                            <constraint firstItem="foD-v2-PKP" firstAttribute="centerX" secondItem="i3P-mu-uGU" secondAttribute="centerX" id="Yj1-ab-hYW"/>
+                            <constraint firstItem="8Jg-9l-J7K" firstAttribute="top" secondItem="bpm-42-M2C" secondAttribute="bottom" id="heW-Y5-nTd"/>
+                            <constraint firstItem="8Jg-9l-J7K" firstAttribute="leading" secondItem="5Jz-VB-beW" secondAttribute="leading" id="o39-EL-6Vf"/>
+                            <constraint firstItem="8Jg-9l-J7K" firstAttribute="trailing" secondItem="5Jz-VB-beW" secondAttribute="trailing" id="wSc-YY-Z70"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="5Jz-VB-beW"/>
+                    </view>
+                    <connections>
+                        <outlet property="_miniMediaControlsContainerView" destination="foD-v2-PKP" id="gOK-BN-m3b"/>
+                        <outlet property="_miniMediaControlsHeightConstraint" destination="NUJ-lX-JXR" id="4z3-V9-CnZ"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0V0-bQ-WMJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-588" y="-1190.5547226386807"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
Added mini controller which is basically a persistent control that allows user to pause/play the media and open the expanded controller by tapping on it from anywhere in the app.

This is how it looks:-

![ezgif com-video-to-gif-3](https://user-images.githubusercontent.com/31038198/61675957-de7b8200-ad17-11e9-9e4a-533836b5815b.gif)

The "floaty" upload button gets hidden behind the mini controller, so we need to fix that. I changed the coordinates to push the button up when mini controller is visible, but it didn't seem to work. (Maybe @Marton-Zeisler can try it out?)

The mini controller automatically becomes visible if an active cast session was on, and the user re-opened the app. It goes away when casting is over or the cast device is disconnected. 