### PR TITLE
Cast: Media starts minimized 

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesViewController+FilesViewDelegates.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesViewController+FilesViewDelegates.swift
@@ -114,7 +114,6 @@ extension FilesViewController: FilesView {
         
         if let remoteMediaClient = sessionManager.currentCastSession?.remoteMediaClient {
             if queueMedia == .playItem {
-                GCKCastContext.sharedInstance().presentDefaultExpandedMediaControls()
                 let mediaQueueItemBuilder = GCKMediaQueueItemBuilder()
                 mediaQueueItemBuilder.mediaInformation = mediaInformation
                 mediaQueueItemBuilder.autoplay = true
@@ -214,7 +213,6 @@ extension FilesViewController: FilesView {
         mediaLoadRequestDataBuilder.mediaInformation = mediaInformation
         if let remoteMediaClient = sessionManager.currentCastSession?.remoteMediaClient {
             if queueMedia == .playItem {
-                GCKCastContext.sharedInstance().presentDefaultExpandedMediaControls()
                 let mediaQueueItemBuilder = GCKMediaQueueItemBuilder()
                 mediaQueueItemBuilder.mediaInformation = mediaInformation
                 mediaQueueItemBuilder.autoplay = true


### PR DESCRIPTION
When a file is casted, it starts minimized in the mini controller. The user can tap the mini controller to open the full screen. 

![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/31038198/61836312-6fc83100-ae9d-11e9-9002-8954dbfb9ab0.gif)
