### PR TITLE
Thumbnails fetched from the server

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Cells/FilesBaseCollectionViewCell.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Cells/FilesBaseCollectionViewCell.swift
@@ -24,9 +24,14 @@ class FilesBaseCollectionCell: SwipeCollectionViewCell{
             return
         }
         
+        guard let urlThumbnail = ServerApi.shared!.getFileThumbnailUri(serverFile) else {
+            AmahiLogger.log("Invalid URL, thumbnail generation failed")
+            return
+        }
+        
         switch type {
         case MimeType.image:
-            iconImageView.sd_setImage(with: url, placeholderImage: UIImage(named: "image"), options: .refreshCached)
+            iconImageView.sd_setImage(with: urlThumbnail, placeholderImage: UIImage(named: "image"), options: .refreshCached)
             break
         case .video:
             if let image = VideoThumbnailGenerator.imageFromMemory(for: url) {

--- a/AmahiAnywhere/AmahiAnywhere/Cells/FilesBaseCollectionViewCell.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Cells/FilesBaseCollectionViewCell.swift
@@ -31,7 +31,12 @@ class FilesBaseCollectionCell: SwipeCollectionViewCell{
         
         switch type {
         case MimeType.image:
-            iconImageView.sd_setImage(with: urlThumbnail, placeholderImage: UIImage(named: "image"), options: .refreshCached)
+            if ServerApi.shared?.getServer()?.name! == "Welcome to Amahi" {
+                iconImageView.sd_setImage(with: url, placeholderImage: UIImage(named: "image"), options: .refreshCached)
+            }
+            else {
+                iconImageView.sd_setImage(with: urlThumbnail, placeholderImage: UIImage(named: "image"), options: .refreshCached)
+            }
             break
         case .video:
             if let image = VideoThumbnailGenerator.imageFromMemory(for: url) {

--- a/AmahiAnywhere/AmahiAnywhere/Data/Remote/ApiCalls/ServerApi.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Data/Remote/ApiCalls/ServerApi.swift
@@ -158,4 +158,19 @@ class ServerApi {
         
         return components.url
     }
+    
+    public func getFileThumbnailUri(_ file: ServerFile) -> URL? {
+        var components = URLComponents(string: serverAddress!)!
+        components.path = "/cache"
+        components.queryItems = [
+            URLQueryItem(name: "s", value: file.parentShare!.name),
+            URLQueryItem(name: "p", value: file.getPath()),
+            URLQueryItem(name: "mtime", value: String(file.getLastModifiedEpoch())),
+            URLQueryItem(name: "session", value: server.session_token)
+        ]
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B")
+        
+        return components.url
+    }
 }


### PR DESCRIPTION
Addresses issue #216 

Since thumbnails for only images are available at the moment, we fetch them only for pictures. 
The welcome server doesn't currently provide these thumbnails, once it does, we will fetch those instead of using full images. 
 