### PR TITLE
Changed LocalStorage(a singleton class) init to private 

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere.xcodeproj/project.pbxproj
+++ b/AmahiAnywhere/AmahiAnywhere.xcodeproj/project.pbxproj
@@ -537,33 +537,16 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-AmahiAnywhere/Pods-AmahiAnywhere-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/Cache/Cache.framework",
-				"${BUILT_PRODUCTS_DIR}/EVReflection/EVReflection.framework",
-				"${BUILT_PRODUCTS_DIR}/IQKeyboardManagerSwift/IQKeyboardManagerSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/Imaginary/Imaginary.framework",
-				"${BUILT_PRODUCTS_DIR}/Lightbox/Lightbox.framework",
-				"${BUILT_PRODUCTS_DIR}/MBProgressHUD/MBProgressHUD.framework",
-				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
-				"${BUILT_PRODUCTS_DIR}/SkyFloatingLabelTextField/SkyFloatingLabelTextField.framework",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AmahiAnywhere/Pods-AmahiAnywhere-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Cache.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/EVReflection.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IQKeyboardManagerSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Imaginary.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lightbox.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MBProgressHUD.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SkyFloatingLabelTextField.framework",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AmahiAnywhere/Pods-AmahiAnywhere-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AmahiAnywhere/Pods-AmahiAnywhere-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AmahiAnywhere/Pods-AmahiAnywhere-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/AmahiAnywhere/AmahiAnywhere/Data/Local/LocalStorage.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Data/Local/LocalStorage.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class LocalStorage: NSObject {
     
-    override init() {
+    private override init() {
         super.init()
     }
     

--- a/AmahiAnywhere/Podfile.lock
+++ b/AmahiAnywhere/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - Alamofire (4.7.3)
+  - Alamofire (4.9.0)
   - Cache (5.2.0)
-  - EVReflection/Alamofire (5.8.0):
+  - EVReflection/Alamofire (5.10.1):
     - Alamofire
     - EVReflection/Core
-  - EVReflection/Core (5.8.0)
+  - EVReflection/Core (5.10.1)
   - Imaginary (4.2.0):
     - Cache (~> 5.0)
-  - IQKeyboardManagerSwift (6.2.0)
+  - IQKeyboardManagerSwift (6.4.2)
   - Lightbox (2.3.0):
     - Imaginary (~> 4.0)
   - MBProgressHUD (1.1.0)
-  - MobileVLCKit (3.1.5)
-  - ReachabilitySwift (4.3.0)
-  - SkyFloatingLabelTextField (3.6.0)
+  - MobileVLCKit (3.3.4)
+  - ReachabilitySwift (4.3.1)
+  - SkyFloatingLabelTextField (3.7.0)
 
 DEPENDENCIES:
   - Alamofire
@@ -39,17 +39,17 @@ SPEC REPOS:
     - SkyFloatingLabelTextField
 
 SPEC CHECKSUMS:
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
+  Alamofire: afc3e7c6db61476cb45cdd23fed06bad03bbc321
   Cache: 807c5d86d01a177f06ede9865add3aea269bbfd4
-  EVReflection: 1f1813b5d1e2c0dbafa2bbc2ec84f8dfb3b72f8b
+  EVReflection: 8124de482178d34ccd56473e16cd95990f9a1113
   Imaginary: dae33d06dbc2ada22f98afef5eb45cc061311a2c
-  IQKeyboardManagerSwift: b07ccf9d8cafe993dcd6cb794eb4ba34611a0c4e
+  IQKeyboardManagerSwift: 79a3ec200dfb41cb66a89b8575417b5378107c5d
   Lightbox: d317750e4132bfb871a5307cfe0a2c7d6a583c65
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  MobileVLCKit: 4d44e56380d0ee41c76f9ec7015d3a4b62a963a3
-  ReachabilitySwift: 408477d1b6ed9779dba301953171e017c31241f3
-  SkyFloatingLabelTextField: 38164979b79512f9ff9288ad8acfc4bbf5d843e3
+  MobileVLCKit: 240fe4772b76ed8985d8acbf165aeba8e605ac9d
+  ReachabilitySwift: 4032e2f59586e11e3b0ebe15b167abdd587a388b
+  SkyFloatingLabelTextField: 4b46db0ab1ccde0919cded29c656e6b4805eda04
 
 PODFILE CHECKSUM: 05f4f94ccd14414605545108b00372bb54dd2d6d
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.7.1


### PR DESCRIPTION
A shared instance of LocalStorage class is used in the app in order to provide Global point access to its object. Since the **init was still public** anyone could create a new object of LocalStorage, killing the whole point of using a shared instance and this provides room for errors.
**Making the init private ensures that creating new objects of this class is prohibited and you are compelled to use the shared instance.**