### PR TITLE
Revert "User Agent Header Added"

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Utils/Network.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Utils/Network.swift
@@ -16,32 +16,12 @@ public class Network {
     
     static let shared = Network()
     
-    //eg. iOS/10_1
-       func deviceVersion() -> String {
-           let currentDevice = UIDevice.current
-           return "\(currentDevice.systemName)/\(currentDevice.systemVersion)"
-       }
-       //eg. iPhone5,2
-       func deviceName() -> String {
-           var sysinfo = utsname()
-           uname(&sysinfo)
-           return String(bytes: Data(bytes: &sysinfo.machine, count: Int(_SYS_NAMELEN)), encoding: .ascii)!.trimmingCharacters(in: .controlCharacters)
-       }
-       //eg. MyApp/1
-       func appNameAndVersion() -> String {
-           let dictionary = Bundle.main.infoDictionary!
-           let version = dictionary["CFBundleShortVersionString"] as! String
-           let name = dictionary["CFBundleName"] as! String
-           return "\(name)/\(version)"
-       }
-       
-       private func getDefaultHeaders() -> HTTPHeaders {
-           return [
-               "Accept": "application/json" +
-               "\(appNameAndVersion()) \(deviceName()) \(deviceVersion())"
-           ]
-       }
-
+    private func getDefaultHeaders() -> HTTPHeaders {
+        return [
+            "Accept": "application/json"
+            // TODO: Add User-Agent header
+        ]
+    }
     
     private func getFinalHeaders(_ headers: HTTPHeaders) -> HTTPHeaders {
         var finalHeaders = getDefaultHeaders()


### PR DESCRIPTION
Reverts amahi/ios#277

Implementation does not add a `User-agent` at all. It appends to the `Accept` header. What the hell?!
I should have reviewed more carefully. 