### PR TITLE
Fixed issue #315 app crash due to 408

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Data/Remote/ApiCalls/ServerApi.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Data/Remote/ApiCalls/ServerApi.swift
@@ -104,6 +104,7 @@ class ServerApi {
     func getShares(completion: @escaping (_ serverShares: [ServerShare]?) -> Void ) {
         if serverRoute == nil{
             completion(nil)
+            return
         }
         
         if serverAddress == nil{

--- a/AmahiAnywhere/AmahiAnywhere/Extensions/String.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Extensions/String.swift
@@ -16,4 +16,5 @@ extension String {
 
 extension Notification.Name {
     static let HDATokenExpired = Notification.Name("HDATokenExpired")
+    static let HDAUnreachable = Notification.Name("HDAUnreachable")
 }

--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesViewController.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesViewController.swift
@@ -103,6 +103,7 @@ class FilesViewController: BaseUIViewController, GCKRemoteMediaClientListener {
         presenter.getFiles(share, directory: directory)
         
         NotificationCenter.default.addObserver(self, selector: #selector(expiredAuthTokenHDA), name: .HDATokenExpired, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(unreachableHDA), name: .HDAUnreachable, object: nil)
         if #available(iOS 13.0, *) {
             self.view.backgroundColor = UIColor.secondarySystemBackground
             filesCollectionView.backgroundColor = UIColor.secondarySystemBackground
@@ -131,6 +132,15 @@ class FilesViewController: BaseUIViewController, GCKRemoteMediaClientListener {
             self.uploadImageTapped()
         }
     }
+    
+    @objc func unreachableHDA(){
+        let alertVC = UIAlertController(title: "Unable to reach HDA", message: "Please check if your HDA is connected and try again.", preferredStyle: .alert)
+        alertVC.addAction(UIAlertAction(title: "OK", style: .default, handler: { (_) in
+            self.navigationController?.popToRootViewController(animated: true)
+        }))
+        self.present(alertVC, animated: true, completion: nil)
+    }
+
     
     @objc func expiredAuthTokenHDA(){
         let alertVC = UIAlertController(title: "Session Expired", message: "Your session expired or was lost. Please login again.", preferredStyle: .alert)

--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Shares/SharesViewController.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Shares/SharesViewController.swift
@@ -34,6 +34,7 @@ class SharesViewController: BaseUIViewController, UICollectionViewDelegate, UICo
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        NotificationCenter.default.addObserver(self, selector: #selector(unreachableHDA), name: .HDAUnreachable, object: nil)
         if server?.name != "Welcome to Amahi"{
             navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Log out", style: .done, target: self, action: #selector(logOutTapped))
             
@@ -75,6 +76,14 @@ class SharesViewController: BaseUIViewController, UICollectionViewDelegate, UICo
             if let serverName = ServerApi.shared?.getServer()?.name{
                 LocalStorage.shared.delete(key: serverName)
             }
+            self.navigationController?.popToRootViewController(animated: true)
+        }))
+        self.present(alertVC, animated: true, completion: nil)
+    }
+    
+    @objc func unreachableHDA(){
+        let alertVC = UIAlertController(title: "Unable to reach HDA", message: "Please check if your HDA is connected and try again.", preferredStyle: .alert)
+        alertVC.addAction(UIAlertAction(title: "OK", style: .default, handler: { (_) in
             self.navigationController?.popToRootViewController(animated: true)
         }))
         self.present(alertVC, animated: true, completion: nil)

--- a/AmahiAnywhere/AmahiAnywhere/Utils/Network.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Utils/Network.swift
@@ -81,7 +81,12 @@ public class Network {
                     NotificationCenter.default.post(name: .HDATokenExpired, object: nil)
                     completion(nil)
                 }
-                
+
+                if response.response?.statusCode == 408{
+                    NotificationCenter.default.post(name:.HDAUnreachable, object: nil)
+                    completion(nil)
+                }
+
 //                AmahiLogger.log("Request to \(url!) returned with STATUS CODE \(response.response?.statusCode)") // <<<<<<<<<<<<<
                 switch response.result {
                     case .success:


### PR DESCRIPTION
this PR handles and shows an error when a 408 response is generated from the server preventing app crash.
 **Fixes issue #315**  
User is shown an alert as shown in the screenshot below. Tapping on OK takes back to available HDAs page.

![](https://user-images.githubusercontent.com/32341862/87858568-6e183880-c94c-11ea-9a9b-cdb0f8b88afb.png)
