### PR TITLE
audio player infinite loop fix

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Presentation/MediaPlayers/Audio Player/AudioPlayerViewController+Player.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/MediaPlayers/Audio Player/AudioPlayerViewController+Player.swift
@@ -38,6 +38,8 @@ extension AudioPlayerViewController{
             return
         }
         
+        resetControls()
+        
         if dataModel.currentIndex >= dataModel.playerItems.count - 1{
             
             //current queue is empty resetting queue
@@ -68,6 +70,7 @@ extension AudioPlayerViewController{
             
             if let item = dataModel.preparePrevious(){
                 updateThumbnailCollectionView(for: .previous)
+                resetControls()
                 player.replaceCurrentItem(with: item)
                 loadSong()
             }


### PR DESCRIPTION
This PR Fixes #339 ( Audio Player went into an infinite loop when restarting queue in "repeating all songs" mode).

Fix:- the current playback time of `AVPlayerItem` object needed to be reset to 0 before removing it from player.