### PR TITLE
Photo browser improvements

### DIFF
--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesViewController+UICollectionViewDelegates.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Files/FilesViewController+UICollectionViewDelegates.swift
@@ -29,6 +29,10 @@ extension FilesViewController: UICollectionViewDataSource, UICollectionViewDeleg
             imageView.sd_setImage(with: URL, placeholderImage: nil, options: .refreshCached, completed: { (image, data, error, true) in
                 completion?(nil)
             })
+            LightboxConfig.CloseButton.textAttributes = [
+                           .font: UIFont.boldSystemFont(ofSize: 18),
+                           .foregroundColor: UIColor.blue
+                       ]
         }
         
         let serverFile = filteredFiles.getFileFromIndexPath(indexPath)

--- a/AmahiAnywhere/AmahiAnywhere/Presentation/Recent Files/RecentFilesViewController+CollectionView.swift
+++ b/AmahiAnywhere/AmahiAnywhere/Presentation/Recent Files/RecentFilesViewController+CollectionView.swift
@@ -21,6 +21,10 @@ extension RecentFilesViewController: UICollectionViewDelegate, UICollectionViewD
             imageView.sd_setImage(with: URL, placeholderImage: nil, options: .refreshCached, completed: { (image, data, error, true) in
                 completion?(nil)
             })
+            LightboxConfig.CloseButton.textAttributes = [
+                           .font: UIFont.boldSystemFont(ofSize: 18),
+                           .foregroundColor: UIColor.blue
+                       ]
         }
         
         let recentFile = filteredRecentFiles[indexPath.item]


### PR DESCRIPTION
### Description

The Close button is white this is often hard to see in bright images. In this PR I changed the foreground color of the close button to blue. But due to the limited customization option in the Lightbox image viewer, we can't change the position of the close button.

Fixes #63 

### Screenshot
![photo123](https://user-images.githubusercontent.com/47811606/91231799-82b9ce80-e74b-11ea-86d0-dccbcb8c6bcb.png)